### PR TITLE
fix: finger-crossed fix asset rootUrls for gh-pages

### DIFF
--- a/config/environment.js
+++ b/config/environment.js
@@ -4,7 +4,7 @@ module.exports = function (environment) {
   let ENV = {
     modulePrefix: 'catechism',
     environment,
-    rootURL: '/',
+    rootURL: '/catechism/',
     locationType: 'history',
     EmberENV: {
       FEATURES: {

--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -32,7 +32,7 @@ module.exports = function (defaults) {
     staticModifiers: true,
     staticComponents: true,
     packagerOptions: {
-      publicAssetURL: '/', // publicAssetURL is similar to Ember CLI's asset fingerprint prepend option.
+      publicAssetURL: isProduction() ? '/catechism/' : '', // publicAssetURL is similar to Ember CLI's asset fingerprint prepend option.
       cssLoaderOptions: {
         sourceMap: isProduction() === false,
         modules: {


### PR DESCRIPTION
When running in GH-pages we are running on the `/catechism/` rootURL, so that url has to be set in config and embroider assets must be configured to use this path.